### PR TITLE
删除：移除了员工管理模块 el-table 组件上硬编码的 size="small" 属性，使其能够自动响应布局大小的切换。

### DIFF
--- a/src/views/system/employee/index.vue
+++ b/src/views/system/employee/index.vue
@@ -103,7 +103,6 @@
         ref="table"
         v-loading="crud?.loading"
         :data="crud?.data"
-        size="small"
         style="width: 100%;"
         @selection-change="crud?.selectionChangeHandler"
         @sort-change="crud?.doTitleOrder"


### PR DESCRIPTION
删除：移除了员工管理模块 el-table 组件上硬编码的 size="small" 属性，使其能够自动响应布局大小的切换。